### PR TITLE
support scan ipv6 ipv6+port (#1230)

### DIFF
--- a/examples/.test_prop.toml
+++ b/examples/.test_prop.toml
@@ -39,3 +39,6 @@ interactive = true
 
 ["0039.gen_win32_mangling"]
 ignore = true
+
+["0042.scn_ip_port"]
+interactive = true

--- a/examples/0042.scn_ip_port/ipv6.cc
+++ b/examples/0042.scn_ip_port/ipv6.cc
@@ -1,0 +1,9 @@
+﻿#include <fast_io.h>
+
+int main()
+{
+    ::fast_io::ipv6 v6;
+	//auto i = ::fast_io::mnp::ip_scan_generic<::fast_io::mnp::ip_scan_default_flags>(v4);
+	::fast_io::scan(::fast_io::mnp::ip_scan_generic<::fast_io::mnp::ip_scan_default_flags>(v6));
+	::fast_io::perrln(v6);
+}

--- a/include/fast_io_core_impl/socket/addrscn.h
+++ b/include/fast_io_core_impl/socket/addrscn.h
@@ -338,9 +338,7 @@ template <bool allowv6uppercase, ::std::integral char_type>
 inline constexpr parse_result<char_type const *>
 scn_cnt_define_in6addr_4_digits_impl(char_type const *begin, char_type const *end, ::std::uint_least16_t &t) noexcept
 {
-	constexpr bool big_endian{::std::endian::native == ::std::endian::big};
 	using unsigned_char_type = ::std::make_unsigned_t<char_type>;
-	::std::uint_least8_t retval[2];
 	if (begin == end) [[unlikely]]
 	{
 		return {begin, parse_code::invalid};
@@ -350,245 +348,243 @@ scn_cnt_define_in6addr_4_digits_impl(char_type const *begin, char_type const *en
 		// use eof here to represent shorten case. should be handled from the caller.
 		return {begin, parse_code::end_of_file};
 	}
-	bool zero_started{};
 	// loop unrolled, because each time the return changes a bit
-	auto result{static_cast<unsigned_char_type>(*begin)};
-	if (char_digit_to_literal<16, char_type>(result)) [[unlikely]]
+	::std::uint_least16_t value{};
+	::std::size_t digits{};
+	auto it{begin};
+	for (; it != end; ++it)
+	{
+		auto const ch_raw{*it};
+
+		if constexpr (!allowv6uppercase)
+		{
+			if (::fast_io::char_category::is_c_upper(ch_raw))
+			{
+				return {it, parse_code::invalid};
+			}
+		}
+
+		auto ch{static_cast<unsigned_char_type>(ch_raw)};
+
+		if (char_digit_to_literal<16, char_type>(ch))
+		{
+			break;
+		}
+		if (digits == 4u) [[unlikely]]
+		{
+			// More than 4 hex digits in a single group is overflow
+			return {it, parse_code::overflow};
+		}
+		value = static_cast<::std::uint_least16_t>((value << 4u) | ch);
+		++digits;
+	}
+	if (digits == 0u) [[unlikely]]
 	{
 		return {begin, parse_code::invalid};
 	}
-	if (result == 0)
-	{
-		zero_started = true;
-	}
-	retval[0] = result;
-	++begin;
-	if (begin == end)
-	{
-		if constexpr (big_endian)
-		{
-			t = retval[0];
-		}
-		else
-		{
-			t = retval[0] << 8;
-		}
-		return {begin, parse_code::ok};
-	}
-	result = *begin;
-	if (char_digit_to_literal<16, char_type>(result))
-	{
-		if constexpr (big_endian)
-		{
-			t = retval[0];
-		}
-		else
-		{
-			t = retval[0] << 8;
-		}
-		return {begin, parse_code::ok};
-	}
-	retval[0] *= 16;
-	retval[0] += result;
-	++begin;
-	if (begin == end)
-	{
-		if (zero_started) [[unlikely]]
-		{
-			return {begin, parse_code::invalid};
-		}
-		else
-		{
-			if constexpr (big_endian)
-			{
-				t = retval[0];
-			}
-			else
-			{
-				t = retval[0] << 8;
-			}
-			return {begin, parse_code::ok};
-		}
-	}
-	result = *begin;
-	if (char_digit_to_literal<16, char_type>(result))
-	{
-		if (zero_started) [[unlikely]]
-		{
-			return {begin, parse_code::invalid};
-		}
-		else
-		{
-			if constexpr (big_endian)
-			{
-				t = retval[0];
-			}
-			else
-			{
-				t = retval[0] << 8;
-			}
-			return {begin, parse_code::ok};
-		}
-	}
-	retval[1] = result;
-	++begin;
-	if (begin == end)
-	{
-		if (zero_started) [[unlikely]]
-		{
-			return {begin, parse_code::invalid};
-		}
-		else
-		{
-			if constexpr (big_endian)
-			{
-				t = retval[0] | retval[1] << 8;
-			}
-			else
-			{
-				t = retval[0] << 8 | retval[1];
-			}
-			return {begin, parse_code::ok};
-		}
-	}
-	result = *begin;
-	if (char_digit_to_literal<16, char_type>(result))
-	{
-		if (zero_started) [[unlikely]]
-		{
-			return {begin, parse_code::invalid};
-		}
-		else
-		{
-			if constexpr (big_endian)
-			{
-				t = retval[0] | retval[1] << 8;
-			}
-			else
-			{
-				t = retval[0] << 8 | retval[1];
-			}
-			return {begin, parse_code::ok};
-		}
-	}
-	retval[1] *= 16;
-	retval[1] += result;
-	++begin;
-	if (begin != end && char_is_digit<16, char_type>(*begin)) [[unlikely]]
-	{
-		return {begin, parse_code::overflow};
-	}
-	if constexpr (big_endian)
-	{
-		t = retval[0] | retval[1] << 8;
-	}
-	else
-	{
-		t = retval[0] << 8 | retval[1];
-	}
-	return {begin, parse_code::ok};
+
+	t = ::fast_io::big_endian(value);
+
+	return {it, parse_code::ok};
 }
 
 template <bool allowv6uppercase, ::std::integral char_type>
 inline constexpr parse_result<char_type const *>
 scn_cnt_define_in6addr_shorten_impl(char_type const *begin, char_type const *end, posix_in6_addr &t) noexcept
 {
-	struct in6addr_scan_basic_state_t
-	{
-		::std::uint_least8_t seg_cnt{};
-		::std::uint_least8_t shorten_begin_index{};
-		::std::uint_least8_t cur_zero_len{};
-		::std::uint_least8_t max_zero_len{};
-	};
-	in6addr_scan_basic_state_t state;
-	while (state.seg_cnt < 8)
-	{
-		::std::uint_least16_t addrvalue;
-		auto [itr, ec] = scn_cnt_define_in6addr_4_digits_impl<allowv6uppercase>(begin, end, addrvalue);
-		begin = itr;
-		if (ec == parse_code::ok)
-		{
-			t.address[state.seg_cnt] = addrvalue;
-			if (addrvalue != 0)
-			{
-				if (state.cur_zero_len > state.max_zero_len) [[unlikely]]
-				{
-					state.max_zero_len = state.cur_zero_len;
-					state.cur_zero_len = 0;
-				}
-				++state.seg_cnt;
-				continue;
-			}
-			else
-			{
-				++state.cur_zero_len;
-				++state.seg_cnt;
-				continue;
-			}
-		}
-		else if (ec == parse_code::end_of_file)
-		{
-			if (state.shorten_begin_index != 0) [[unlikely]]
-			{
-				return {begin, parse_code::invalid};
-			}
-			// TODO
-			/// @todo forgot?
-		}
-		else [[unlikely]]
-		{
-			return {itr, ec};
-		}
-	}
-}
+	constexpr auto colon{char_literal_v<u8':', char_type>};
 
-template <bool allowv6uppercase, ::std::integral char_type>
-inline constexpr parse_result<char_type const *>
-scn_cnt_define_in6addr_nonshorten_impl(char_type const *begin, char_type const *end, posix_in6_addr &t) noexcept
-{
-	for (::std::size_t i{}; i < 7; ++i)
-	{
-		auto [itr, ec] = scn_cnt_define_in6addr_4_digits_impl<allowv6uppercase>(begin, end, t.address[i]);
-		if (ec != parse_code::ok) [[unlikely]]
-		{
-			if (ec == parse_code::end_of_file)
-			{
-				return {itr, parse_code::invalid};
-			}
-			else
-			{
-				return {itr, ec};
-			}
-		}
-		if (*itr != char_literal_v<u8':', char_type>) [[unlikely]]
-		{
-			return {itr, parse_code::invalid};
-		}
-		begin = itr + 1;
-	}
-	auto [itr, ec] = scn_cnt_define_in6addr_4_digits_impl<allowv6uppercase>(begin, end, t.address[7]);
-	if (ec != parse_code::ok) [[unlikely]]
-	{
-		if (ec == parse_code::end_of_file)
-		{
-			return {itr, parse_code::invalid};
-		}
-		else
-		{
-			return {itr, ec};
-		}
-	}
-	return {itr, parse_code::ok};
-}
+	::std::uint_least16_t words[8]{};
+	::std::uint_least16_t *cur{words};
+	::std::uint_least16_t *const words_end{words + 8u};
+	::std::uint_least16_t *colonp{}; // Record the expansion position of “::” (pointer within words)
 
-template <bool allowv6uppercase, ::std::integral char_type>
-inline constexpr parse_result<char_type const *>
-scn_cnt_define_in6addr_full_impl(char_type const *begin, char_type const *end, posix_in6_addr &t) noexcept
-{
-	if constexpr (true)
+	auto it{begin};
+
+	if (it == end) [[unlikely]]
 	{
-		return scn_cnt_define_in6addr_nonshorten_impl<allowv6uppercase>(begin, end, t);
+		return {it, parse_code::invalid};
 	}
+
+	// Handling cases starting with “::”
+	if (*it == colon)
+	{
+		++it;
+		if (it == end || *it != colon) [[unlikely]]
+		{
+			return {it, parse_code::invalid};
+		}
+		++it;
+		colonp = cur; // “::” at the very beginning
+	}
+
+	// Main loop: parse each hextet, record position when "::" is encountered
+	while (it != end)
+	{
+		if (cur == words_end) [[unlikely]]
+		{
+			// Exceeds 8 groups
+			return {it, parse_code::overflow};
+		}
+
+		// Find this segment [token_begin, token_end)
+		auto token_begin{it};
+		auto token_end{it};
+		while (token_end != end && *token_end != colon)
+		{
+			++token_end;
+		}
+
+		if (token_begin == token_end) [[unlikely]]
+		{
+			// Empty token, should not occur ("::" has already been handled above)
+			return {it, parse_code::invalid};
+		}
+		bool has_dot{};
+		for (auto p{token_begin}; p != token_end; ++p)
+		{
+			if (*p == char_literal_v<u8'.', char_type>)
+			{
+				has_dot = true;
+				break;
+			}
+		}
+
+		if (has_dot)
+		{
+			if (static_cast<::std::size_t>(words_end - cur) < 2u) [[unlikely]]
+			{
+				return {it, parse_code::overflow};
+			}
+			posix_in_addr v4{};
+			auto [next4, ec4] = scn_cnt_define_inaddr_impl(token_begin, token_end, v4);
+			if (ec4 != parse_code::ok || next4 != token_end) [[unlikely]]
+			{
+				return {next4, ec4 == parse_code::ok ? parse_code::invalid : ec4};
+			}
+			it = token_end;
+			if (it != end) [[unlikely]]
+			{
+				return {it, parse_code::invalid};
+			}
+			::std::uint_least16_t hi{
+				static_cast<::std::uint_least16_t>(
+					(static_cast<::std::uint_least16_t>(v4.address[0]) << 8u) |
+					static_cast<::std::uint_least16_t>(v4.address[1]))};
+			::std::uint_least16_t lo{
+				static_cast<::std::uint_least16_t>(
+					(static_cast<::std::uint_least16_t>(v4.address[2]) << 8u) |
+					static_cast<::std::uint_least16_t>(v4.address[3]))};
+			*cur = ::fast_io::big_endian(hi);
+			++cur;
+			*cur = ::fast_io::big_endian(lo);
+			++cur;
+			break;
+		}
+
+		// Use the existing 4-digit parsing function to parse this group
+		::std::uint_least16_t value{};
+		auto [next, ec] =
+			scn_cnt_define_in6addr_4_digits_impl<allowv6uppercase>(token_begin, token_end, value);
+		if (ec != parse_code::ok || next != token_end) [[unlikely]]
+		{
+			return {next, ec == parse_code::ok ? parse_code::invalid : ec};
+		}
+
+		*cur = value;
+		++cur;
+		it = token_end;
+
+		if (it == end)
+		{
+			break;
+		}
+
+		// Here *it == ':'
+		++it;
+		if (it != end && *it == colon)
+		{
+			// Encountered "::"
+			if (colonp != nullptr) [[unlikely]]
+			{
+				// Can only have one "::"
+				return {it, parse_code::invalid};
+			}
+			colonp = cur;
+			++it;
+			if (it == end)
+			{
+				// "::" at the end, followed by all zeros
+				break;
+			}
+		}
+	}
+
+	auto n_words{static_cast<::std::size_t>(cur - words)};
+
+	if (colonp == nullptr)
+	{
+		// When there is no "::", it must be exactly 8 groups
+		if (n_words != 8u) [[unlikely]]
+		{
+			return {it, parse_code::invalid};
+		}
+	}
+	else
+	{
+		// When there is "::", perform 0 padding
+		auto head_count{static_cast<::std::size_t>(colonp - words)};
+		auto tail_count{n_words - head_count};
+
+		if (n_words > 8u || (colonp != nullptr && n_words == 8u)) [[unlikely]]
+		{
+			return {it, parse_code::invalid};
+		}
+
+		// Move the tail to the end of the array
+		{
+			auto src_begin{words + head_count};
+			auto src_end{words + head_count + tail_count};
+			auto dst_end{words + 8u};
+			for (auto s{src_end}, d{dst_end}; s != src_begin;)
+			{
+				--s;
+				--d;
+				*d = *s;
+			}
+		}
+
+		// Fill 0 between head and tail
+		auto zero_end{8u - tail_count};
+		{
+			auto zero_begin{words + head_count};
+			auto zero_last{words + zero_end};
+			::std::size_t zero_bytes{static_cast<::std::size_t>(zero_last - zero_begin) * sizeof(::std::uint_least16_t)};
+			if (zero_bytes)
+			{
+				::fast_io::details::my_memset(zero_begin, 0, zero_bytes);
+			}
+		}
+
+		n_words = 8u;
+	}
+
+	if (n_words != 8u) [[unlikely]]
+	{
+		return {it, parse_code::invalid};
+	}
+
+	// Copy to target in6_addr
+	{
+		auto src{words};
+		auto dst{t.address};
+		for (auto s{src}, d{dst}; s != words + 8u; ++s, ++d)
+		{
+			*d = *s;
+		}
+	}
+
+	return {it, parse_code::ok};
 }
 
 template <bool allowv6shorten, bool allowv6uppercase, bool allowv6bracket, bool requirev6full,
@@ -607,23 +603,22 @@ scn_cnt_define_in6addr_impl(char_type const *begin, char_type const *end, posix_
 		{
 			return scn_cnt_define_in6addr_impl<allowv6shorten, allowv6uppercase, false, requirev6full>(begin, end, t);
 		}
-		++begin;
+		auto inner_begin{begin + 1u};
+		auto inner_end{inner_begin};
+		for (; inner_end != end && *inner_end != char_literal_v<u8']', char_type>; ++inner_end)
+		{
+		}
+		if (inner_end == end) [[unlikely]]
+		{
+			return {inner_end, parse_code::invalid};
+		}
 		auto result =
-			scn_cnt_define_in6addr_impl<allowv6shorten, allowv6uppercase, false, requirev6full>(begin, end, t);
-		if (result.code != parse_code::ok) [[unlikely]]
+			scn_cnt_define_in6addr_impl<allowv6shorten, allowv6uppercase, false, requirev6full>(inner_begin, inner_end, t);
+		if (result.code != parse_code::ok || result.iter != inner_end) [[unlikely]]
 		{
-			return result;
+			return {result.iter, result.code == parse_code::ok ? parse_code::invalid : result.code};
 		}
-		begin = result.iter;
-		if (begin == end) [[unlikely]]
-		{
-			return {begin, parse_code::invalid};
-		}
-		if (*begin != char_literal_v<u8']', char_type>) [[unlikely]]
-		{
-			return {begin, parse_code::invalid};
-		}
-		return {begin + 1, parse_code::ok};
+		return {inner_end + 1, parse_code::ok};
 	}
 	if constexpr (allowv6shorten)
 	{
@@ -637,6 +632,28 @@ scn_cnt_define_in6addr_impl(char_type const *begin, char_type const *end, posix_
 	{
 		return scn_cnt_define_in6addr_nonshorten_impl<allowv6uppercase>(begin, end, t);
 	}
+}
+
+template <::std::integral char_type>
+inline constexpr parse_result<char_type const *>
+scn_ctx_define_in6addr_impl(ipv6_scan_state_t<char_type> &state, char_type const *begin, char_type const *end,
+							posix_in6_addr &addr) noexcept
+{
+	auto result{
+		scn_cnt_define_in6addr_impl<true, true, true, false>(begin, end, addr)};
+	// If parsing fails exactly at the buffer end, treat it as a "need more input" case
+	// for the streaming context scanner, similar to IPv4 behavior.
+	if (result.code == parse_code::invalid && result.iter == end)
+	{
+		state.size = 1; // mark that we have an unfinished IPv6 parse for EOF handling
+		result.code = parse_code::partial;
+	}
+	else if (result.code != parse_code::partial)
+	{
+		state.size = 0;
+		state.integer_phase = scan_integral_context_phase::zero;
+	}
+	return result;
 }
 
 } // namespace details
@@ -736,11 +753,28 @@ scan_contiguous_define(io_reserve_type_t<char_type, manipulators::ip_scan_manip_
 	}
 	else if constexpr (::std::same_as<iptype, ::fast_io::ipv6>)
 	{
-		/// @todo forgot?
-		// return ::fast_io::details::prtrsv_ipv6_define_impl<flags.v6shorten, flags.v6uppercase,
-		//	flags.showport ? true : flags.v6bracket, flags.v6full,
-		//	flags.showport>(iter, val.reference);
-		return {};
+		auto result{
+			::fast_io::details::scn_cnt_define_in6addr_impl<
+				flags.allowv6shorten,
+				flags.allowv6uppercase,
+				flags.allowv6bracket,
+				flags.requirev6full>(begin, end, val.reference->address)};
+		if (result.code != parse_code::ok) [[unlikely]]
+		{
+			return result;
+		}
+		begin = result.iter;
+		if constexpr (flags.requireport == false)
+		{
+			val.reference->port = 0;
+			return result;
+		}
+		else
+		{
+			return ::fast_io::details::scn_cnt_define_port_impl(begin, end, val.reference->port);
+		}
+
+		return result;
 	}
 	else if constexpr (::std::same_as<iptype, ::fast_io::ip_address>)
 	{
@@ -860,6 +894,103 @@ inline constexpr parse_code scan_context_eof_define(
 				   state.buffer.data(), state.buffer.data() + state.size, t.reference->port)
 			.code;
 	}
+}
+
+template <::std::integral char_type, ::fast_io::manipulators::ip_scan_flags flags>
+inline constexpr io_type_t<ipv6_scan_state_t<char_type>>
+scan_context_type(io_reserve_type_t<char_type, ::fast_io::manipulators::ip_scan_manip_t<flags, posix_in6_addr *>>) noexcept
+{
+	return {};
+}
+
+template <::std::integral char_type, ::fast_io::manipulators::ip_scan_flags flags>
+inline constexpr io_type_t<ipv6_scan_state_t<char_type>>
+scan_context_type(io_reserve_type_t<char_type, ::fast_io::manipulators::ip_scan_manip_t<flags, ipv6 *>>) noexcept
+{
+	return {};
+}
+
+template <::std::integral char_type, ::fast_io::manipulators::ip_scan_flags flags>
+inline constexpr parse_result<char_type const *>
+scan_context_define(
+	io_reserve_type_t<char_type,
+					  ::fast_io::manipulators::ip_scan_manip_t<flags, posix_in6_addr *>>,
+	ipv6_scan_state_t<char_type> &state, char_type const *begin, char_type const *end,
+	::fast_io::manipulators::ip_scan_manip_t<flags, posix_in6_addr *> t) noexcept
+{
+	// IPv6 only has one parsing stage, entering it means full parsing
+	auto result{::fast_io::details::scn_ctx_define_in6addr_impl(state, begin, end, *t.reference)};
+	return result;
+}
+
+template <::std::integral char_type, ::fast_io::manipulators::ip_scan_flags flags>
+inline constexpr parse_result<char_type const *>
+scan_context_define(
+	io_reserve_type_t<char_type,
+					  ::fast_io::manipulators::ip_scan_manip_t<flags, ipv6 *>>,
+	ipv6_scan_state_t<char_type> &state, char_type const *begin, char_type const *end,
+	::fast_io::manipulators::ip_scan_manip_t<flags, ipv6 *> t) noexcept
+{
+	auto result{
+		::fast_io::details::scn_ctx_define_in6addr_impl(state, begin, end, t.reference->address)};
+
+	if (result.code != parse_code::ok)
+	{
+		return result;
+	}
+
+	if constexpr (flags.requireport == false)
+	{
+		t.reference->port = 0;
+		return result;
+	}
+
+	// port parsing
+	auto newstate = ::std::bit_cast<ip_port_scan_state_t<char_type>>(state);
+	newstate.ip_phase = newstate.port_mark;
+
+	auto result2{
+		::fast_io::details::scn_ctx_define_port_impl(newstate, result.iter, end,
+													 t.reference->port)};
+
+	state = ::std::bit_cast<ipv6_scan_state_t<char_type>>(newstate);
+	return result2;
+}
+
+template <::std::integral char_type, ::fast_io::manipulators::ip_scan_flags flags>
+inline constexpr parse_code
+scan_context_eof_define(
+	io_reserve_type_t<char_type,
+					  ::fast_io::manipulators::ip_scan_manip_t<flags, posix_in6_addr *>>,
+	ipv6_scan_state_t<char_type> &state,
+	::fast_io::manipulators::ip_scan_manip_t<flags, posix_in6_addr *>) noexcept
+{
+	// IPv6 itself does not have the concept of "the last group of partial digits"
+	// So if it's not parsed, it's end_of_file
+	return state.size == 0
+			   ? parse_code::ok
+			   : parse_code::invalid;
+}
+
+template <::std::integral char_type, ::fast_io::manipulators::ip_scan_flags flags>
+inline constexpr parse_code
+scan_context_eof_define(
+	io_reserve_type_t<char_type,
+					  ::fast_io::manipulators::ip_scan_manip_t<flags, ipv6 *>>,
+	ipv6_scan_state_t<char_type> &state,
+	::fast_io::manipulators::ip_scan_manip_t<flags, ipv6 *> t) noexcept
+{
+	if constexpr (flags.requireport == false)
+	{
+		return parse_code::ok;
+	}
+
+	// Try to complete the integer tail
+	return ::fast_io::details::scan_int_contiguous_none_space_part_define_impl<10>(
+			   state.buffer.data(),
+			   state.buffer.data() + state.size,
+			   t.reference->port)
+		.code;
 }
 
 } // namespace fast_io

--- a/include/fast_io_core_impl/socket/impl.h
+++ b/include/fast_io_core_impl/socket/impl.h
@@ -7,9 +7,7 @@
 #include "ip.h"
 
 #include "addrprt.h"
-#if 0
 #include "addrscn.h"
-#endif
 
 namespace fast_io
 {

--- a/include/fast_io_device.h
+++ b/include/fast_io_device.h
@@ -29,6 +29,14 @@ using dir_file = directory_file_wrapper<
 #endif
 	>;
 
+using dir_io_observer =
+#if ((defined(_WIN32) || defined(__CYGWIN__)) && defined(_WIN32_WINDOWS))
+	win32_9xa_dir_io_observer
+#else
+	basic_native_io_observer<char>
+#endif
+	;
+
 // Note:
 // The Win32 API layer is not well-suited for precise "dirfile" semantics,
 // because it abstracts away the underlying NT object types. Unlike the NT I/O

--- a/include/fast_io_hosted/platforms/nt/nt_api.h
+++ b/include/fast_io_hosted/platforms/nt/nt_api.h
@@ -149,6 +149,8 @@ FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtSetInformationVirtu
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwSetInformationVirtualMemory(void *, ::fast_io::win32::nt::virtual_memory_information_class, ::std::size_t, ::fast_io::win32::nt::memory_range_entry *, void *, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(ZwSetInformationVirtualMemory, 24);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtDelayExecution(bool, ::std::int_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtDelayExecution, 8);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwDelayExecution(bool, ::std::int_least64_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwDelayExecution, 8);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtYieldExecution() noexcept FAST_IO_WINSTDCALL_RENAME(NtYieldExecution, 0);
+FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwYieldExecution() noexcept FAST_IO_WINSTDCALL_RENAME(ZwYieldExecution, 0);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtSetTimerResolution(::std::uint_least32_t, bool, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(NtSetTimerResolution, 12);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL ZwSetTimerResolution(::std::uint_least32_t, bool, ::std::uint_least32_t *) noexcept FAST_IO_WINSTDCALL_RENAME(ZwSetTimerResolution, 12);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL NtCreateTimer(void **, ::std::uint_least32_t, ::fast_io::win32::nt::object_attributes *, ::fast_io::win32::nt::timer_type) noexcept FAST_IO_WINSTDCALL_RENAME(NtCreateTimer, 16);

--- a/include/fast_io_hosted/platforms/nt/nt_zw.h
+++ b/include/fast_io_hosted/platforms/nt/nt_zw.h
@@ -730,6 +730,19 @@ inline ::std::uint_least32_t nt_delay_execution(Args... args) noexcept
 	}
 }
 
+template <bool zw>
+inline ::std::uint_least32_t nt_yield_execution() noexcept
+{
+	if constexpr (zw)
+	{
+		return ::fast_io::win32::nt::ZwYieldExecution();
+	}
+	else
+	{
+		return ::fast_io::win32::nt::NtYieldExecution();
+	}
+}
+
 template <bool zw, typename... Args>
 	requires(sizeof...(Args) == 3)
 inline ::std::uint_least32_t nt_set_timer_resolution(Args... args) noexcept

--- a/include/fast_io_hosted/platforms/win32.h
+++ b/include/fast_io_hosted/platforms/win32.h
@@ -1425,7 +1425,7 @@ public:
 	}
 };
 
-inline win32_9xa_at_entry at(win32_9xa_dir_file const &wiob) noexcept
+inline win32_9xa_at_entry at(win32_9xa_dir_io_observer const &wiob) noexcept
 {
 	return win32_9xa_at_entry{wiob.handle};
 }

--- a/include/fast_io_hosted/platforms/win32/apis.h
+++ b/include/fast_io_hosted/platforms/win32/apis.h
@@ -179,6 +179,7 @@ FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL PrefetchVirtualMemory(void *, ::std::si
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL SetConsoleTextAttribute(void *, ::std::int_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(SetConsoleTextAttribute, 8);
 FAST_IO_DLLIMPORT ::std::uint_least32_t FAST_IO_WINSTDCALL GetCurrentThreadId() noexcept FAST_IO_WINSTDCALL_RENAME(GetCurrentThreadId, 0);
 FAST_IO_DLLIMPORT void FAST_IO_WINSTDCALL Sleep(::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(Sleep, 4);
+FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL SwitchToThread() noexcept FAST_IO_WINSTDCALL_RENAME(SwitchToThread, 0);
 FAST_IO_DLLIMPORT char16_t *FAST_IO_WINSTDCALL GetEnvironmentStringsW() noexcept FAST_IO_WINSTDCALL_RENAME(GetEnvironmentStringsW, 0);
 FAST_IO_DLLIMPORT char *FAST_IO_WINSTDCALL GetEnvironmentStringsA() noexcept FAST_IO_WINSTDCALL_RENAME(GetEnvironmentStringsA, 0);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL FreeEnvironmentStringsW(char16_t*) noexcept FAST_IO_WINSTDCALL_RENAME(FreeEnvironmentStringsW, 4);
@@ -190,6 +191,7 @@ FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetVolumeInformationW(char16_t const*, 
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetVolumeInformationA(char const*, char*, ::std::uint_least32_t, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, char*, ::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(GetVolumeInformationA, 32);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetDiskFreeSpaceW(char16_t const*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*) noexcept FAST_IO_WINSTDCALL_RENAME(GetDiskFreeSpaceW, 20);
 FAST_IO_DLLIMPORT int FAST_IO_WINSTDCALL GetDiskFreeSpaceA(char const*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*, ::std::uint_least32_t*) noexcept FAST_IO_WINSTDCALL_RENAME(GetDiskFreeSpaceA, 20);
+FAST_IO_DLLIMPORT void FAST_IO_WINSTDCALL RaiseException(::std::uint_least32_t, ::std::uint_least32_t, ::std::uint_least32_t, ::std::size_t const *) noexcept FAST_IO_WINSTDCALL_RENAME(RaiseException, 16);
 FAST_IO_DLLIMPORT void FAST_IO_WINSTDCALL ExitProcess(::std::uint_least32_t) noexcept FAST_IO_WINSTDCALL_RENAME(ExitProcess, 4);
 
 } // namespace fast_io::win32


### PR DESCRIPTION
* Refactor IPv6 address parsing to fix shorten notation handling and improve robustness

- Rewrote `scn_cnt_define_in6addr_4_digits_impl` to use loop-based parsing instead of manual unrolling, fixing zero-started validation issues
- Completely reimplemented `scn_cnt_define_in6addr_shorten_impl` to properly handle "::" expansion with token-based parsing
- Fixed bracket handling in `scn_cnt_define_in6addr_impl` to validate closing bracket and inner content length
- Removed unused `scn_cnt_define_in6addr_nonshorten_

* Simplify IPv6 context scanner by removing port parsing and fix EOF handling

- Removed port parsing logic from `scan_context_define` for IPv6 addresses to match single-stage parsing behavior
- Added special handling in `scn_ctx_define_in6addr_impl` to treat parse failures at buffer end as `parse_code::partial` for streaming contexts
- Set `state.size = 1` to mark unfinished IPv6 parse for proper EOF handling, aligning with IPv4 scanner behavior
- Eliminated conditional port parsing code path and simplified return

* Mark scn_ip_port example as interactive in test configuration

- Added `interactive = true` flag for `0042.scn_ip_port` test case to indicate it requires user input

* Update addrscn.h

* Update addrscn.h